### PR TITLE
Prevent InitFakePlayer to be called from clientside

### DIFF
--- a/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
+++ b/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
@@ -66,7 +66,7 @@ public class AdvancedDrawbridgeLogic extends InventoryLogic implements IFacingLo
     // Completely necessary due to the way players load chunks, including fake ones.
     private void initFakePlayer ()
     {
-        if (fakePlayer == null && !isInvalid())
+        if (fakePlayer == null && !isInvalid() && !worldObj.isRemote)
             fakePlayer = new FakePlayerLogic(new GameProfile(null, "Player.Drawbridge"), this);
     }
 

--- a/src/main/java/tmechworks/blocks/logic/DrawbridgeLogic.java
+++ b/src/main/java/tmechworks/blocks/logic/DrawbridgeLogic.java
@@ -63,7 +63,7 @@ public class DrawbridgeLogic extends InventoryLogic implements IFacingLogic, IAc
     // Completely necessary due to the way players load chunks, including fake ones.
     private void initFakePlayer ()
     {
-        if (fakePlayer == null && !isInvalid())
+        if (fakePlayer == null && !isInvalid() && !worldObj.isRemote)
             fakePlayer = new FakePlayerLogic(new GameProfile(null, "Player.Drawbridge"), this);
     }
 


### PR DESCRIPTION
Will fix the issue with casting WorldClient to WorldServer.

```
java.lang.ClassCastException: net.minecraft.client.multiplayer.WorldClient cannot be cast to net.minecraft.world.WorldServer

    at tmechworks.lib.player.FakePlayerLogic.<init>(FakePlayerLogic.java:16)
    at tmechworks.blocks.logic.AdvancedDrawbridgeLogic.initFakePlayer(AdvancedDrawbridgeLogic.java:70)
    at tmechworks.blocks.logic.AdvancedDrawbridgeLogic.func_145845_h(AdvancedDrawbridgeLogic.java:340)
    at net.minecraft.world.World.func_72939_s(World.java:1912)
    at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1995)
    at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:962)
    at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:887)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(-2)
    at sun.reflect.NativeMethodAccessorImpl.invoke(-1)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(-1)
    at java.lang.reflect.Method.invoke(-1)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:134)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
```
