### PR TITLE
More closely imitate block placement process from ItemBlock

### DIFF
--- a/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
+++ b/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
@@ -478,6 +478,7 @@ public class AdvancedDrawbridgeLogic extends InventoryLogic implements IFacingLo
      */
     public boolean placeBlockAt (ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ, int metadata, Block block)
     {
+    	metadata = block.onBlockPlaced(world, x, y, z, side, hitX, hitY, hitZ, metadata);
         if (!world.setBlock(x, y, z, block, metadata, 3))
         {
             return false;

--- a/src/main/java/tmechworks/blocks/logic/DrawbridgeLogic.java
+++ b/src/main/java/tmechworks/blocks/logic/DrawbridgeLogic.java
@@ -456,6 +456,7 @@ public class DrawbridgeLogic extends InventoryLogic implements IFacingLogic, IAc
      */
     public boolean placeBlockAt (ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ, int metadata, Block block)
     {
+    	metadata = block.onBlockPlaced(world, x, y, z, side, hitX, hitY, hitZ, metadata);
         if (!world.setBlock(x, y, z, block, metadata, 3))
         {
             return false;


### PR DESCRIPTION
This pull request adds code to the Drawbridge and Advanced Drawbridge logic classes to more closely imitate the block placement process found in ItemBlock.  The added call ends up fixing an issue with ComputerCraft monitor placement by the drawbridges.

![2015-02-01_22 57 48](https://cloud.githubusercontent.com/assets/967831/5996872/e7368114-aa66-11e4-9ed5-56ad874d744a.png)

In the above screenshot, all drawbridges were loaded with three advanced monitor blocks, then extended.  The old behavior is demonstrated by the drawbridges on the left.  The new (correct) behavior is demonstrated on the right (though both kinds of drawbridges are fixed; that screenshot is in-progress from my testing).
