### PR TITLE
Created a stop-gap hotfix to prevent a dupe bug from being exploited …

### DIFF
--- a/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
+++ b/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
@@ -311,8 +311,8 @@ public class AdvancedDrawbridgeLogic extends InventoryLogic implements IFacingLo
                 ticks = 0;
                 if (active) // Placement
                 {
-                	//TODO: Remove && !inventory[0].hasTagCompound() and modify the retraction section. See todo below.
-                    if (getStackInSlot(extension) != null && getStackInSlot(extension).stackSize > 0 && extension < 15 && !inventory[0].hasTagCompound())
+                	//TODO: Remove && !getStackInSlot(extension).hasTagCompound() and modify the retraction section. See todo below.
+                    if (getStackInSlot(extension) != null && getStackInSlot(extension).stackSize > 0 && extension < 15 && !getStackInSlot(extension).hasTagCompound())
                     {
                         extension++;
                         int xPos = xCoord;
@@ -411,8 +411,8 @@ public class AdvancedDrawbridgeLogic extends InventoryLogic implements IFacingLo
                 else
                 // Retraction
                 {
-                	//TODO: Remove && !inventory[0].hasTagCompound() and add some code that recreates the inventory[0] ItemStack from the block being retracted instead of loading from bufferStack. See todo below.
-                    if ((getStackInSlot(extension) == null || getStackInSlot(extension).stackSize < getStackInSlot(extension).getMaxStackSize()) && extension > 0 && !inventory[0].hasTagCompound())
+                	//TODO: Remove && getStackInSlot(extension).hasTagCompound() and add some code that recreates the getStackInSlot(extension) ItemStack from the block being retracted instead of loading from bufferStack. See todo below.
+                    if ((getStackInSlot(extension) == null || getStackInSlot(extension).stackSize < getStackInSlot(extension).getMaxStackSize()) && extension > 0 && getStackInSlot(extension).hasTagCompound())
                     {
                         int xPos = xCoord;
                         int yPos = yCoord;

--- a/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
+++ b/src/main/java/tmechworks/blocks/logic/AdvancedDrawbridgeLogic.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import mantle.blocks.BlockUtils;
 import mantle.blocks.abstracts.InventoryLogic;
 import mantle.blocks.iface.IActiveLogic;
 import mantle.blocks.iface.IFacingLogic;
@@ -312,7 +311,8 @@ public class AdvancedDrawbridgeLogic extends InventoryLogic implements IFacingLo
                 ticks = 0;
                 if (active) // Placement
                 {
-                    if (getStackInSlot(extension) != null && getStackInSlot(extension).stackSize > 0 && extension < 15)
+                	//TODO: Remove && !inventory[0].hasTagCompound() and modify the retraction section. See todo below.
+                    if (getStackInSlot(extension) != null && getStackInSlot(extension).stackSize > 0 && extension < 15 && !inventory[0].hasTagCompound())
                     {
                         extension++;
                         int xPos = xCoord;
@@ -411,7 +411,8 @@ public class AdvancedDrawbridgeLogic extends InventoryLogic implements IFacingLo
                 else
                 // Retraction
                 {
-                    if ((getStackInSlot(extension) == null || getStackInSlot(extension).stackSize < getStackInSlot(extension).getMaxStackSize()) && extension > 0)
+                	//TODO: Remove && !inventory[0].hasTagCompound() and add some code that recreates the inventory[0] ItemStack from the block being retracted instead of loading from bufferStack. See todo below.
+                    if ((getStackInSlot(extension) == null || getStackInSlot(extension).stackSize < getStackInSlot(extension).getMaxStackSize()) && extension > 0 && !inventory[0].hasTagCompound())
                     {
                         int xPos = xCoord;
                         int yPos = yCoord;
@@ -449,6 +450,7 @@ public class AdvancedDrawbridgeLogic extends InventoryLogic implements IFacingLo
                                 if (worldObj.setBlock(xPos, yPos, zPos, Blocks.air))
                                     if (getStackInSlot(extension - 1) == null)
                                     {
+                                    	//TODO: This is creating a dupe issue. See todo above.
                                         setInventorySlotContents(extension - 1, getStackInBufferSlot(extension - 1).copy());
                                     }
                                     else

--- a/src/main/java/tmechworks/blocks/logic/DrawbridgeLogic.java
+++ b/src/main/java/tmechworks/blocks/logic/DrawbridgeLogic.java
@@ -27,7 +27,6 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.Facing;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
-import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.ForgeDirection;
 import tmechworks.inventory.DrawbridgeContainer;
 import tmechworks.lib.TMechworksRegistry;
@@ -297,7 +296,8 @@ public class DrawbridgeLogic extends InventoryLogic implements IFacingLogic, IAc
                 ticks = 0;
                 if (active) //Placement
                 {
-                    if (inventory[0] != null && inventory[0].stackSize > 0 && extension < maxExtension)
+                	//TODO: Remove && !inventory[0].hasTagCompound() and modify the retraction section. See todo below.
+                    if (inventory[0] != null && inventory[0].stackSize > 0 && extension < maxExtension && !inventory[0].hasTagCompound())
                     {
                         extension++;
                         int xPos = xCoord;
@@ -393,7 +393,8 @@ public class DrawbridgeLogic extends InventoryLogic implements IFacingLogic, IAc
                 else
                 //Retraction
                 {
-                    if ((inventory[0] == null || inventory[0].stackSize < inventory[0].getMaxStackSize()) && extension > 0)
+                	//TODO: Remove && !inventory[0].hasTagCompound() and add some code that recreates the inventory[0] ItemStack from the block being retracted instead of loading from bufferStack. See todo below.
+                    if ((inventory[0] == null || inventory[0].stackSize < inventory[0].getMaxStackSize()) && extension > 0 && !inventory[0].hasTagCompound())
                     {
                         int xPos = xCoord;
                         int yPos = yCoord;
@@ -431,6 +432,7 @@ public class DrawbridgeLogic extends InventoryLogic implements IFacingLogic, IAc
                                 if (worldObj.setBlock(xPos, yPos, zPos, Blocks.air))
                                     if (inventory[0] == null)
                                     {
+                                    	//TODO: This is creating a dupe issue. See todo above.
                                         inventory[0] = bufferStack.copy();
                                     }
                                     else


### PR DESCRIPTION
…when the banlist is empty. Ideally, this should be removed and replaced with code to recreate the inventory ItemStack from the in-world block being retracted.